### PR TITLE
Modified tests and chunking algorithm

### DIFF
--- a/tests/cases/06_gridfs.ts
+++ b/tests/cases/06_gridfs.ts
@@ -31,7 +31,10 @@ export default function gridfsTests() {
       bucketName: "deno_logo",
     });
 
-    const upstream = bucket.openUploadStream("deno_logo.png");
+    // Set an impractically low chunkSize to test chunking algorithm
+    const upstream = bucket.openUploadStream("deno_logo.png", {
+      chunkSizeBytes: 255 * 8,
+    });
 
     await (await fetch("https://deno.land/images/deno_logo.png")).body!.pipeTo(
       upstream,


### PR DESCRIPTION
I noticed that the image being used for the tests has a size of ~14KiB, way less than a default GridFS chunk, by changing chunkSizeBytes in the upload options we can test the chunking algorithm. It was not working so I fixed it.